### PR TITLE
Create workflow for Dependabot security-labeled PRs to auto-merge

### DIFF
--- a/.github/workflows/dependabot-security-auto-merge.yml
+++ b/.github/workflows/dependabot-security-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Auto-merge Dependabot security updates
+
+on:
+  pull_request_target:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  automerge:
+    # only run on Dependabot PRs that have the “security” label
+    if: |
+      github.actor == 'dependabot[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'security')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-approve Dependabot security PR
+        uses: hmarr/auto-approve-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # restrict to Security updates only
+          # hmarr/auto-approve-action@v2 satisfies the 1-reviewer requirement automatically
+
+      - name: Enable auto-merge for security fixes
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash


### PR DESCRIPTION
# Description

Closes CU-86aa5j2nk

Add a GitHub Actions workflow that automatically approves and enables auto-merge (squash) for Dependabot PRs labeled `security`, allowing security updates to merge once all CI checks pass without requiring a separate human review.


## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing instructions

1. Push this workflow to the `development` branch.

2. Create or reopen a Dependabot pull request that updates a dependency and ensure it is labeled security.

3. Observe that the job:

 - Auto-approves the PR (using `hmarr/auto-approve-action@v2`),

 - Enables auto-merge with squash (`using peter-evans/enable-pull-request-automerge@v3`).

4. Confirm that the branch-protection rules (CI status checks and “1 reviewer required”) still apply, and once they pass, the PR merges itself.

## Screenshots (if applicable)

<!-- Add screenshots here to demonstrate the UI changes.-->

This workflow only triggers for `dependabot[bot]` and PRs with the `security` label.

All other Dependabot PRs (without the `security` label) will continue to require a human reviewer as before.

Uses `pull_request_target` to ensure the runner has write permissions on the base branch.

<!-- Anything else the reviewers should be aware of?-->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have tested my feature thoroughly in different environments.
- [ ] I have added tests that prove my feature works as intended.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have assessed the performance impact of the feature.
- [ ] My changes do not introduce new warnings or errors.
- [ ] I have checked for compatibility with other parts of the codebase.
