### PR TITLE
Adding in eslient check just for components and making it match pascal

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+    "plugins": ["filenames"],
+    "overrides": [
+      {
+        "files": ["src/components/**/*.{js,jsx,ts,tsx}"],
+        "rules": {
+          "filenames/match-regex": [2, "^[A-Z][a-zA-Z0-9]+$", true]
+        }
+      }
+    ]
+  }
+  

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,12 +1,11 @@
 {
-    "plugins": ["filenames"],
-    "overrides": [
-      {
-        "files": ["src/components/**/*.{js,jsx,ts,tsx}"],
-        "rules": {
-          "filenames/match-regex": [2, "^[A-Z][a-zA-Z0-9]+$", true]
-        }
+  "plugins": ["filenames"],
+  "overrides": [
+    {
+      "files": ["src/components/**/*.{js,jsx,ts,tsx}"],
+      "rules": {
+        "filenames/match-regex": [2, "^[A-Z][a-zA-Z0-9]+$", true]
       }
-    ]
-  }
-  
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@vitejs/plugin-react": "^4.4.1",
         "eslint": "^9",
         "eslint-config-next": "15.3.5",
+        "eslint-plugin-filenames": "^1.3.2",
         "jsdom": "^26.1.0",
         "tailwindcss": "^4",
         "tsx": "^4.20.1",
@@ -4935,6 +4936,22 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-plugin-filenames": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-filenames/-/eslint-plugin-filenames-1.3.2.tgz",
+      "integrity": "sha512-tqxJTiEM5a0JmRCUYQmxw23vtTxrb2+a3Q2mMOPhFxvt7ZQQJmdiuMby9B/vUAuVMghyP7oET+nIf6EO6CBd/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.camelcase": "4.3.0",
+        "lodash.kebabcase": "4.1.1",
+        "lodash.snakecase": "4.1.1",
+        "lodash.upperfirst": "4.3.1"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    },
     "node_modules/eslint-plugin-import": {
       "version": "2.32.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
@@ -6684,10 +6701,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@vitejs/plugin-react": "^4.4.1",
     "eslint": "^9",
     "eslint-config-next": "15.3.5",
+    "eslint-plugin-filenames": "^1.3.2",
     "jsdom": "^26.1.0",
     "tailwindcss": "^4",
     "tsx": "^4.20.1",


### PR DESCRIPTION
# Description

Closes: C86aa5j5p2

Adds in checking of files under the component folder to be Pascal case checks for **js,jsx,ts,tsx** extensions.  Once things are all **.tsx** then maybe we just check for that file extension

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing instructions

Check out this branch and run this command:

`npx eslint src/components`

Ensuring nothing is returned


## Additional Remarks

If you do not specify a folder path it takes longer as it looks through the whole project.

## Checklist

- [x ] My code adheres to the project's coding and style guidelines.
- [x ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have tested my feature thoroughly in different environments.
- [ ] I have added tests that prove my feature works as intended.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have assessed the performance impact of the feature.
- [ ] My changes do not introduce new warnings or errors.
- [ ] I have checked for compatibility with other parts of the codebase.
