### PR TITLE
Remove the test to create a public project as it's not necessary

### DIFF
--- a/supabase/__tests__/rls-policies/projects.test.ts
+++ b/supabase/__tests__/rls-policies/projects.test.ts
@@ -47,21 +47,17 @@ describe('RLS Policies for Projects Table', async () => {
     expect(error).toBeNull();
   });
 
-  //Test case: Ensure authenticated users can create public projects
-  it('should allow authenticated users to create public projects', async () => {
-    // Create a new project object with public visibility
-    const project = await newProject();
-    project.visibility = 'public';
-
-    // Use the authenticated client to insert a new project
-    const { data, error } = await authedClient
+  // Test case: Ensure private projects are not accessible to unauthenticated users
+  it('should not allow unauthenticated users to get private projects', async () => {
+    // Use the unauthenticated client to fetch private projects
+    const { data, error } = await unauthClient
       .from('projects')
-      .insert(project)
-      .select();
+      .select('*')
+      .eq('visibility', 'private');
 
-    // Expect data to be defined and not empty
-    expect(data).toBeDefined();
-    expect(error).toBeNull();
+    // Expect no data and an error
+    expect(data?.length).toBe(0);
+    expect(error).toBeDefined();
   });
 
   // Test case: Ensure unauthenticated users can not update projects
@@ -122,19 +118,6 @@ describe('RLS Policies for Projects Table', async () => {
     expect(error).toBeNull();
   });
 
-  // Test case: Ensure private projects are not accessible to unauthenticated users
-  it('should not allow unauthenticated users to get private projects', async () => {
-    // Use the unauthenticated client to fetch private projects
-    const { data, error } = await unauthClient
-      .from('projects')
-      .select('*')
-      .eq('visibility', 'private');
-
-    // Expect no data and an error
-    expect(data?.length).toBe(0);
-    expect(error).toBeDefined();
-  });
-
   // Test case: Ensure authenticated users cannot access private projects they do not own
   it('should not allow authenticated users to get private projects they do not own', async () => {
     // Use the authenticated client to fetch private projects
@@ -147,21 +130,6 @@ describe('RLS Policies for Projects Table', async () => {
     // Expect no data and an error
     expect(data?.length).toBe(0);
     expect(error).toBeDefined();
-  });
-
-  // Test case: Ensure authenticated users can access their own private projects
-  it('should allow authenticated users to get their own private projects', async () => {
-    // Use the authenticated client to fetch private projects
-    const { data, error } = await authedClient
-      .from('projects')
-      .select('*')
-      .eq('visibility', 'private')
-      .eq('owner_id', (await newProject()).owner_id);
-
-    // Expect data to be defined and not empty
-    expect(data).toBeDefined();
-    expect(data?.length).toBeGreaterThan(0);
-    expect(error).toBeNull();
   });
 
   // Test case: Ensure unauthenticated users cannot delete projects


### PR DESCRIPTION
# Description

Removed some testing logic that shouldn't have been there and then updated the select statement to be before the update so it could test getting the private project for the user that created it.

## Type of Change

- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing instructions

Run:
```
npm run test
```
And all the tests should pass without a problem as long as the database has been seeded.

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have tested my feature thoroughly in different environments.
- [ ] I have added tests that prove my feature works as intended.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have assessed the performance impact of the feature.
- [ ] My changes do not introduce new warnings or errors.
- [ ] I have checked for compatibility with other parts of the codebase.
