### PR TITLE
Protected staging env

### DIFF
--- a/src/app/staging-auth/StagingAuth.tsx
+++ b/src/app/staging-auth/StagingAuth.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import StagingAuthSchema, { StagingAuthSchemaType } from './stagingAuth.schema';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Card, CardTitle } from '@/components/ui/card';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { authenticateStaging } from './actions';
+
+export default function StagingAuth() {
+  const form = useForm<StagingAuthSchemaType>({
+    resolver: zodResolver(StagingAuthSchema),
+    mode: 'onChange',
+    defaultValues: {
+      password: '',
+    },
+  });
+
+  const onSubmit = async (formData: StagingAuthSchemaType) => {
+    return await authenticateStaging(formData);
+  };
+
+  return (
+    <section>
+      <Card>
+        <CardTitle>{'Access Staging Environment'}</CardTitle>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <FormField
+              control={form.control}
+              name='password'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{'Password'}</FormLabel>
+                  <FormControl>
+                    <Input type='password' {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    {'Enter staging environment password'}
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </form>
+        </Form>
+      </Card>
+    </section>
+  );
+}

--- a/src/app/staging-auth/StagingAuth.tsx
+++ b/src/app/staging-auth/StagingAuth.tsx
@@ -26,34 +26,39 @@ export default function StagingAuth() {
   });
 
   const onSubmit = async (formData: StagingAuthSchemaType) => {
-    return await authenticateStaging(formData);
+    const result = await authenticateStaging(formData);
+
+    if (result && !result.success) {
+      form.setError('password', {
+        type: 'manual',
+        message: 'Invalid password',
+      });
+    }
   };
 
   return (
-    <section>
-      <Card>
-        <CardTitle>{'Access Staging Environment'}</CardTitle>
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)}>
-            <FormField
-              control={form.control}
-              name='password'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{'Password'}</FormLabel>
-                  <FormControl>
-                    <Input type='password' {...field} />
-                  </FormControl>
-                  <FormDescription>
-                    {'Enter staging environment password'}
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </form>
-        </Form>
-      </Card>
-    </section>
+    <Card className='p-6 w-3/4 md:w-1/3 lg:w-1/5'>
+      <CardTitle>{'Access Staging Environment'}</CardTitle>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <FormField
+            control={form.control}
+            name='password'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{'Password'}</FormLabel>
+                <FormControl>
+                  <Input type='password' {...field} />
+                </FormControl>
+                <FormDescription>
+                  {'Enter staging environment password'}
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </form>
+      </Form>
+    </Card>
   );
 }

--- a/src/app/staging-auth/actions.ts
+++ b/src/app/staging-auth/actions.ts
@@ -6,8 +6,8 @@ import { StagingAuthSchemaType } from './stagingAuth.schema';
 
 export async function authenticateStaging(formData: StagingAuthSchemaType) {
   const { password } = formData;
-
-  if (password === process.env.STAGING_AUTH_PASS) {
+  console.log(password);
+  if (password === process.env.NEXT_PUBLIC_STAGING_PASS) {
     (await cookies()).set('staging-auth', 'true', {
       maxAge: 60 * 60 * 2,
       httpOnly: true,

--- a/src/app/staging-auth/actions.ts
+++ b/src/app/staging-auth/actions.ts
@@ -1,0 +1,23 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { StagingAuthSchemaType } from './stagingAuth.schema';
+
+export async function authenticateStaging(formData: StagingAuthSchemaType) {
+  const { password } = formData;
+
+  if (password === process.env.STAGING_AUTH_PASS) {
+    (await cookies()).set('staging-auth', 'true', {
+      maxAge: 60 * 60 * 2,
+      httpOnly: true,
+      secure: true,
+      sameSite: 'strict',
+      path: '/',
+    });
+
+    redirect('/');
+  }
+
+  return { success: false };
+}

--- a/src/app/staging-auth/page.tsx
+++ b/src/app/staging-auth/page.tsx
@@ -1,0 +1,9 @@
+import StagingAuth from './StagingAuth';
+
+export default async function Page() {
+  return (
+    <section className='h-full min-h-[90svh] flex flex-col items-center justify-center'>
+      <StagingAuth />
+    </section>
+  );
+}

--- a/src/app/staging-auth/stagingAuth.schema.ts
+++ b/src/app/staging-auth/stagingAuth.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+const StagingAuthSchema = z.object({
+  password: z.string().min(2).max(32),
+});
+
+export type StagingAuthSchemaType = z.infer<typeof StagingAuthSchema>;
+
+export default StagingAuthSchema;

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,84 +1,84 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Card({ className, ...props }: React.ComponentProps<"div">) {
+function Card({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
-      data-slot="card"
+      data-slot='card'
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
         className
       )}
       {...props}
     />
-  )
+  );
 }
 
-function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
-      data-slot="card-header"
+      data-slot='card-header'
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
         className
       )}
       {...props}
     />
-  )
+  );
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
-      data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      data-slot='card-title'
+      className={cn('leading-none font-semibold', className)}
       {...props}
     />
-  )
+  );
 }
 
-function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
-      data-slot="card-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      data-slot='card-description'
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
-  )
+  );
 }
 
-function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
-      data-slot="card-action"
+      data-slot='card-action'
       className={cn(
-        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        'col-start-2 row-span-2 row-start-1 self-start justify-self-end',
         className
       )}
       {...props}
     />
-  )
+  );
 }
 
-function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
-      data-slot="card-content"
-      className={cn("px-6", className)}
+      data-slot='card-content'
+      className={cn('px-6', className)}
       {...props}
     />
-  )
+  );
 }
 
-function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
-      data-slot="card-footer"
-      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      data-slot='card-footer'
+      className={cn('flex items-center px-6 [.border-t]:pt-6', className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -89,4 +89,4 @@ export {
   CardAction,
   CardDescription,
   CardContent,
-}
+};

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -1,13 +1,29 @@
-import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 import { createAnonClient } from './server';
-import { SupabaseClient } from '@supabase/supabase-js';
-import { Database } from 'supabase/supabase.types';
 
 const protectedRoutes = ['/dashboard', '/profile', '/onboarding'];
 const publicRoutes = ['/auth'];
 
 export async function updateSession(request: NextRequest) {
+  const isStaging = process.env.NEXT_PUBLIC_STAGING === 'true';
+
+  if (isStaging) {
+    const stagingAuth = request.cookies.get('staging-auth');
+    const isStagingAuthPage = request.nextUrl.pathname === '/staging-auth';
+
+    if (!stagingAuth?.value && !isStagingAuthPage) {
+      return NextResponse.redirect(new URL('/staging-auth', request.url));
+    }
+
+    if (stagingAuth?.value && isStagingAuthPage) {
+      return NextResponse.redirect(new URL('/', request.url));
+    }
+
+    if (isStagingAuthPage) {
+      return NextResponse.next();
+    }
+  }
+
   let supabaseResponse = NextResponse.next({
     request,
   });

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -6,10 +6,14 @@ const publicRoutes = ['/auth'];
 
 export async function updateSession(request: NextRequest) {
   const isStaging = process.env.NEXT_PUBLIC_STAGING === 'true';
+  const isStagingAuthPage = request.nextUrl.pathname === '/staging-auth';
+
+  if (!isStaging && isStagingAuthPage) {
+    return NextResponse.redirect(new URL('/', request.url));
+  }
 
   if (isStaging) {
     const stagingAuth = request.cookies.get('staging-auth');
-    const isStagingAuthPage = request.nextUrl.pathname === '/staging-auth';
 
     if (!stagingAuth?.value && !isStagingAuthPage) {
       return NextResponse.redirect(new URL('/staging-auth', request.url));


### PR DESCRIPTION
# Description

Adds password protection to staging environment

Closes: CU-86aanxkah

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing instructions

in your local .env file set the following :
```
NEXT_PUBLIC_STAGING=true
NEXT_PUBLIC_STAGING_PASS=builtinpublic
```

- start the app, you should be presented with a password protect screen when attempting to visit any route
- enter the password from above (builtinpublic)
- the screen should clear and you should be on the landing page with an http-only cookie set for staging-auth

delete the cookie
update NEXT_PUBLIC_STAGING to any other value, or just blank, and restart the app

- you should no longer be presented with the password protect screen

## Additional Remarks

the cookie expires after two hours
once validated, you should not be able to return to /staging-auth (redirected to home)

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have tested my feature thoroughly in different environments.
- [ ] I have added tests that prove my feature works as intended.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have assessed the performance impact of the feature.
- [ ] My changes do not introduce new warnings or errors.
- [ ] I have checked for compatibility with other parts of the codebase.
