### PR TITLE
splits large cookies and stores/retrieves them in chunks

### DIFF
--- a/src/app/auth/oauth/route.ts
+++ b/src/app/auth/oauth/route.ts
@@ -26,7 +26,6 @@ export async function GET(req: Request) {
           scopes: 'openid email profile',
           queryParams: {
             access_type: 'online',
-            include_granted_scopes: 'false',
           },
         }
       : {};

--- a/utils/supabase/NextJSCookieStorage.ts
+++ b/utils/supabase/NextJSCookieStorage.ts
@@ -14,13 +14,11 @@ export class NextJSCookieStorage {
 
   getItem(key: string): string | null {
     try {
-      // First try to get the item as a single cookie
       const singleValue = this.cookieStore.get(key)?.value;
       if (singleValue) {
         return singleValue;
       }
 
-      // If no single cookie, try to reconstruct from chunks
       return this.getChunkedItem(key);
     } catch (error) {
       console.error(
@@ -32,7 +30,6 @@ export class NextJSCookieStorage {
 
   private getChunkedItem(key: string): string | null {
     try {
-      // Get the chunk count
       const chunkCountCookie = this.cookieStore.get(`${key}_count`);
       if (!chunkCountCookie?.value) {
         return null;
@@ -43,12 +40,10 @@ export class NextJSCookieStorage {
         return null;
       }
 
-      // Reconstruct the value from chunks
       let reconstructed = '';
       for (let i = 0; i < chunkCount; i++) {
         const chunkCookie = this.cookieStore.get(`${key}_${i}`);
         if (!chunkCookie?.value) {
-          // Missing chunk - return null to indicate corrupted data
           console.warn(`[AUTH DEBUG] Missing chunk ${i} for cookie ${key}`);
           return null;
         }
@@ -66,9 +61,8 @@ export class NextJSCookieStorage {
 
   setItem(key: string, value: string): void {
     try {
-      // If value is small enough, store as single cookie
       if (value.length <= this.maxChunkSize) {
-        // Clean up any existing chunks first
+        // clean up any existing chunks first
         this.removeChunkedItem(key);
 
         const cookieOptions = {
@@ -84,11 +78,6 @@ export class NextJSCookieStorage {
         return;
       }
 
-      // Value is too large, use chunking
-      console.warn(
-        `[AUTH DEBUG] Cookie ${key} is large (${value.length} chars) - using chunked storage`
-      );
-
       this.setChunkedItem(key, value);
     } catch (error) {
       console.error(
@@ -99,7 +88,7 @@ export class NextJSCookieStorage {
 
   private setChunkedItem(key: string, value: string): void {
     try {
-      // Remove any existing single cookie
+      // remove any existing single cookie
       this.cookieStore.set({
         name: key,
         value: '',
@@ -107,7 +96,6 @@ export class NextJSCookieStorage {
         maxAge: 0,
       });
 
-      // Split value into chunks
       const chunks: string[] = [];
       for (let i = 0; i < value.length; i += this.maxChunkSize) {
         chunks.push(value.slice(i, i + this.maxChunkSize));
@@ -121,14 +109,12 @@ export class NextJSCookieStorage {
         maxAge: 60 * 60 * 24 * 365,
       };
 
-      // Set chunk count cookie
       this.cookieStore.set({
         name: `${key}_count`,
         value: chunks.length.toString(),
         ...cookieOptions,
       });
 
-      // Set each chunk
       chunks.forEach((chunk, index) => {
         this.cookieStore.set({
           name: `${key}_${index}`,
@@ -136,8 +122,6 @@ export class NextJSCookieStorage {
           ...cookieOptions,
         });
       });
-
-      console.log(`[AUTH DEBUG] Set ${chunks.length} chunks for cookie ${key}`);
     } catch (error) {
       console.error(
         `[AUTH DEBUG] Error setting chunked cookie ${key}: ${JSON.stringify(error, null, 2)}`
@@ -147,7 +131,6 @@ export class NextJSCookieStorage {
 
   removeItem(key: string): void {
     try {
-      // Remove single cookie
       this.cookieStore.set({
         name: key,
         value: '',
@@ -155,7 +138,6 @@ export class NextJSCookieStorage {
         maxAge: 0,
       });
 
-      // Remove chunked cookies
       this.removeChunkedItem(key);
     } catch (error) {
       console.error(
@@ -166,12 +148,11 @@ export class NextJSCookieStorage {
 
   private removeChunkedItem(key: string): void {
     try {
-      // Get chunk count to know how many chunks to remove
       const chunkCountCookie = this.cookieStore.get(`${key}_count`);
       if (chunkCountCookie?.value) {
         const chunkCount = parseInt(chunkCountCookie.value);
+
         if (!isNaN(chunkCount)) {
-          // Remove each chunk
           for (let i = 0; i < chunkCount; i++) {
             this.cookieStore.set({
               name: `${key}_${i}`,
@@ -183,7 +164,6 @@ export class NextJSCookieStorage {
         }
       }
 
-      // Remove chunk count cookie
       this.cookieStore.set({
         name: `${key}_count`,
         value: '',
@@ -197,48 +177,11 @@ export class NextJSCookieStorage {
     }
   }
 
-  // Utility method to check if a cookie is chunked
   isChunked(key: string): boolean {
     try {
       return !!this.cookieStore.get(`${key}_count`)?.value;
     } catch {
       return false;
-    }
-  }
-
-  // Utility method to get cookie info for debugging
-  getCookieInfo(key: string): {
-    exists: boolean;
-    isChunked: boolean;
-    size?: number;
-    chunks?: number;
-  } {
-    try {
-      const singleCookie = this.cookieStore.get(key);
-      const chunkCountCookie = this.cookieStore.get(`${key}_count`);
-
-      if (singleCookie?.value) {
-        return {
-          exists: true,
-          isChunked: false,
-          size: singleCookie.value.length,
-        };
-      }
-
-      if (chunkCountCookie?.value) {
-        const chunkCount = parseInt(chunkCountCookie.value);
-        const reconstructed = this.getChunkedItem(key);
-        return {
-          exists: true,
-          isChunked: true,
-          size: reconstructed?.length,
-          chunks: chunkCount,
-        };
-      }
-
-      return { exists: false, isChunked: false };
-    } catch {
-      return { exists: false, isChunked: false };
     }
   }
 }

--- a/utils/supabase/NextJSCookieStorage.ts
+++ b/utils/supabase/NextJSCookieStorage.ts
@@ -2,15 +2,26 @@ import { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adap
 
 export class NextJSCookieStorage {
   private cookieStore: ReadonlyRequestCookies;
+  private maxChunkSize: number;
 
-  constructor(cookieStore: ReadonlyRequestCookies) {
+  constructor(
+    cookieStore: ReadonlyRequestCookies,
+    maxChunkSize: number = 3000
+  ) {
     this.cookieStore = cookieStore;
+    this.maxChunkSize = maxChunkSize; // Leave buffer under 4096 limit
   }
 
   getItem(key: string): string | null {
     try {
-      const value = this.cookieStore.get(key)?.value ?? null;
-      return value;
+      // First try to get the item as a single cookie
+      const singleValue = this.cookieStore.get(key)?.value;
+      if (singleValue) {
+        return singleValue;
+      }
+
+      // If no single cookie, try to reconstruct from chunks
+      return this.getChunkedItem(key);
     } catch (error) {
       console.error(
         `[AUTH DEBUG] Error getting cookie ${key}: ${JSON.stringify(error, null, 2)}`
@@ -19,25 +30,66 @@ export class NextJSCookieStorage {
     }
   }
 
-  setItem(key: string, value: string): void {
+  private getChunkedItem(key: string): string | null {
     try {
-      if (value.length > 4000) {
-        console.warn(
-          `[AUTH DEBUG] Cookie ${key} is very large (${value.length} chars) - may exceed browser limits`
-        );
+      // Get the chunk count
+      const chunkCountCookie = this.cookieStore.get(`${key}_count`);
+      if (!chunkCountCookie?.value) {
+        return null;
       }
 
-      const cookieOptions = {
-        name: key,
-        value: value,
-        httpOnly: true,
-        secure: true,
-        sameSite: 'none' as const,
-        path: '/',
-        maxAge: 60 * 60 * 24 * 365,
-      };
+      const chunkCount = parseInt(chunkCountCookie.value);
+      if (isNaN(chunkCount) || chunkCount <= 0) {
+        return null;
+      }
 
-      this.cookieStore.set(cookieOptions);
+      // Reconstruct the value from chunks
+      let reconstructed = '';
+      for (let i = 0; i < chunkCount; i++) {
+        const chunkCookie = this.cookieStore.get(`${key}_${i}`);
+        if (!chunkCookie?.value) {
+          // Missing chunk - return null to indicate corrupted data
+          console.warn(`[AUTH DEBUG] Missing chunk ${i} for cookie ${key}`);
+          return null;
+        }
+        reconstructed += chunkCookie.value;
+      }
+
+      return reconstructed;
+    } catch (error) {
+      console.error(
+        `[AUTH DEBUG] Error reconstructing chunked cookie ${key}: ${JSON.stringify(error, null, 2)}`
+      );
+      return null;
+    }
+  }
+
+  setItem(key: string, value: string): void {
+    try {
+      // If value is small enough, store as single cookie
+      if (value.length <= this.maxChunkSize) {
+        // Clean up any existing chunks first
+        this.removeChunkedItem(key);
+
+        const cookieOptions = {
+          name: key,
+          value: value,
+          httpOnly: true,
+          secure: true,
+          sameSite: 'none' as const,
+          path: '/',
+          maxAge: 60 * 60 * 24 * 365,
+        };
+        this.cookieStore.set(cookieOptions);
+        return;
+      }
+
+      // Value is too large, use chunking
+      console.warn(
+        `[AUTH DEBUG] Cookie ${key} is large (${value.length} chars) - using chunked storage`
+      );
+
+      this.setChunkedItem(key, value);
     } catch (error) {
       console.error(
         `[AUTH DEBUG] Error setting cookie ${key}: ${JSON.stringify(error, null, 2)}`
@@ -45,18 +97,148 @@ export class NextJSCookieStorage {
     }
   }
 
-  removeItem(key: string): void {
+  private setChunkedItem(key: string, value: string): void {
     try {
+      // Remove any existing single cookie
       this.cookieStore.set({
         name: key,
         value: '',
         httpOnly: true,
         maxAge: 0,
       });
+
+      // Split value into chunks
+      const chunks: string[] = [];
+      for (let i = 0; i < value.length; i += this.maxChunkSize) {
+        chunks.push(value.slice(i, i + this.maxChunkSize));
+      }
+
+      const cookieOptions = {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'none' as const,
+        path: '/',
+        maxAge: 60 * 60 * 24 * 365,
+      };
+
+      // Set chunk count cookie
+      this.cookieStore.set({
+        name: `${key}_count`,
+        value: chunks.length.toString(),
+        ...cookieOptions,
+      });
+
+      // Set each chunk
+      chunks.forEach((chunk, index) => {
+        this.cookieStore.set({
+          name: `${key}_${index}`,
+          value: chunk,
+          ...cookieOptions,
+        });
+      });
+
+      console.log(`[AUTH DEBUG] Set ${chunks.length} chunks for cookie ${key}`);
+    } catch (error) {
+      console.error(
+        `[AUTH DEBUG] Error setting chunked cookie ${key}: ${JSON.stringify(error, null, 2)}`
+      );
+    }
+  }
+
+  removeItem(key: string): void {
+    try {
+      // Remove single cookie
+      this.cookieStore.set({
+        name: key,
+        value: '',
+        httpOnly: true,
+        maxAge: 0,
+      });
+
+      // Remove chunked cookies
+      this.removeChunkedItem(key);
     } catch (error) {
       console.error(
         `[AUTH DEBUG] Error removing cookie ${key}: ${JSON.stringify(error, null, 2)}`
       );
+    }
+  }
+
+  private removeChunkedItem(key: string): void {
+    try {
+      // Get chunk count to know how many chunks to remove
+      const chunkCountCookie = this.cookieStore.get(`${key}_count`);
+      if (chunkCountCookie?.value) {
+        const chunkCount = parseInt(chunkCountCookie.value);
+        if (!isNaN(chunkCount)) {
+          // Remove each chunk
+          for (let i = 0; i < chunkCount; i++) {
+            this.cookieStore.set({
+              name: `${key}_${i}`,
+              value: '',
+              httpOnly: true,
+              maxAge: 0,
+            });
+          }
+        }
+      }
+
+      // Remove chunk count cookie
+      this.cookieStore.set({
+        name: `${key}_count`,
+        value: '',
+        httpOnly: true,
+        maxAge: 0,
+      });
+    } catch (error) {
+      console.error(
+        `[AUTH DEBUG] Error removing chunked cookies for ${key}: ${JSON.stringify(error, null, 2)}`
+      );
+    }
+  }
+
+  // Utility method to check if a cookie is chunked
+  isChunked(key: string): boolean {
+    try {
+      return !!this.cookieStore.get(`${key}_count`)?.value;
+    } catch {
+      return false;
+    }
+  }
+
+  // Utility method to get cookie info for debugging
+  getCookieInfo(key: string): {
+    exists: boolean;
+    isChunked: boolean;
+    size?: number;
+    chunks?: number;
+  } {
+    try {
+      const singleCookie = this.cookieStore.get(key);
+      const chunkCountCookie = this.cookieStore.get(`${key}_count`);
+
+      if (singleCookie?.value) {
+        return {
+          exists: true,
+          isChunked: false,
+          size: singleCookie.value.length,
+        };
+      }
+
+      if (chunkCountCookie?.value) {
+        const chunkCount = parseInt(chunkCountCookie.value);
+        const reconstructed = this.getChunkedItem(key);
+        return {
+          exists: true,
+          isChunked: true,
+          size: reconstructed?.length,
+          chunks: chunkCount,
+        };
+      }
+
+      return { exists: false, isChunked: false };
+    } catch {
+      return { exists: false, isChunked: false };
     }
   }
 }


### PR DESCRIPTION
# Description

Refactors NextJSCookieStorage to split cookies over 3000 chars and store/retrieve them in chunks to allow setting large (Google) cookies as http-only

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing instructions

<!-- Instructions on how to test the changes made in the pull
request, helping reviewers validate the code. -->

## Screenshots (if applicable)

<!-- Add screenshots here to demonstrate the UI changes.-->

## Additional Remarks

<!-- Anything else the reviewers should be aware of?-->

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have tested my feature thoroughly in different environments.
- [ ] I have added tests that prove my feature works as intended.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have assessed the performance impact of the feature.
- [ ] My changes do not introduce new warnings or errors.
- [ ] I have checked for compatibility with other parts of the codebase.
