### PR TITLE
adds profile visibility

### DIFF
--- a/supabase/migrations/20250830223716_private_profile.sql
+++ b/supabase/migrations/20250830223716_private_profile.sql
@@ -1,0 +1,11 @@
+create type "public"."profile_visibility" as enum ('public', 'platform', 'private');
+
+alter table "public"."profiles" add column "visibility" "public"."profile_visibility" not null default 'platform';
+
+drop policy if exists "Anyone can view auth users" ON "auth"."users";
+drop policy if exists "Allow insert for authenticated users" on "public"."profiles";
+drop policy if exists "authenticated users can read profiles" on "public"."profiles";
+
+create policy "Anyone can view public profiles" on "public"."profiles" for select using (visibility = 'public');
+create policy "Any authenticated user can view platform profiles" on "public"."profiles" for select to authenticated using (visibility = 'platform');
+create policy "Authenticated users can view their own profiles" on "public"."profiles" for select using (auth.uid() = id);


### PR DESCRIPTION
# Description

Unticketed

Adds profile visibility to profile tables

- `public` can be viewed by anyone on the internet
- `platform` can be viewed by any authenticated user of the platform
- `private` only the profile owner can view

the default setting is `platform`

## Type of Change

- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing instructions

while logged out, no test profiles should be viewable.

in the local supabase dashboard set one of the test profiles to `private`
log in as a different test user, you should be able to see your profile as well as any other profile set to `platform`, but not the profile set to `private`

## Screenshots (if applicable)

<!-- Add screenshots here to demonstrate the UI changes.-->

## Additional Remarks

<!-- Anything else the reviewers should be aware of?-->

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have tested my feature thoroughly in different environments.
- [ ] I have added tests that prove my feature works as intended.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have assessed the performance impact of the feature.
- [ ] My changes do not introduce new warnings or errors.
- [ ] I have checked for compatibility with other parts of the codebase.
