### PR TITLE
Adjust gradientBlobs to use custom css properties to avoid rewriting csp

### DIFF
--- a/src/app/(main)/[username]/components/GradientBlobs.tsx
+++ b/src/app/(main)/[username]/components/GradientBlobs.tsx
@@ -48,11 +48,16 @@ const GradientBlobs = () => {
           <div
             key={index}
             className={`bg-gradient-to-r ${gradientClass} rounded-full blur-[100px] absolute -z-10 opacity-30 transition-all duration-1000`}
-            style={{
-              transform: `translate(${position.x}px, ${position.y}px)`,
-              width: `${position.size}px`,
-              height: `${position.size}px`,
-            }}
+            style={
+              {
+                '--blob-x': `${position.x}px`,
+                '--blob-y': `${position.y}px`,
+                '--blob-size': `${position.size}px`,
+                transform: 'translate(var(--blob-x), var(--blob-y))',
+                width: 'var(--blob-size)',
+                height: 'var(--blob-size)',
+              } as React.CSSProperties
+            }
           />
         );
       })}


### PR DESCRIPTION
# Description

Updated the component to create variables to use instead of regular in-line css to prevent the need to add nonces or hashes to the csp.

**Ticket Number:** [86abn1r2a](https://app.clickup.com/t/86abn1r2a)

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing instructions

This should prevent the error within the staging environment within the profile page.
The error would be about adding unsafe-inlince, hashes, or nonces to the csp for the inline css

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested my feature thoroughly in different environments.
- [ ] I have added tests that prove my feature works as intended.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have assessed the performance impact of the feature.
- [x] My changes do not introduce new warnings or errors.
- [x] I have checked for compatibility with other parts of the codebase.
