### PR TITLE
Potential fix for code scanning alert no. 5: Log injection

### DIFF
--- a/src/use-cases/projects/EditProject.ts
+++ b/src/use-cases/projects/EditProject.ts
@@ -73,8 +73,9 @@ export class EditProject extends BaseMutationUseCase<UpdateProjectParams> {
 
       return { success: true, message: 'Project updated!' };
     } catch (e) {
+      const safeProjectId = projectId.replace(/\r|\n/g, "");
       console.error(
-        `Update failed for project: ${projectId} with: ${JSON.stringify(e, null, 2)}`
+        `Update failed for project: ${safeProjectId} with: ${JSON.stringify(e, null, 2)}`
       );
       return { success: false, message: 'Project update failed' };
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Christin-paige/BuiltInPublic/security/code-scanning/5](https://github.com/Christin-paige/BuiltInPublic/security/code-scanning/5)

To fix log injection vulnerabilities, we need to sanitize any user input included in log statements to ensure it cannot alter log structure. For plain text logs, the standard approach is to remove (or encode) newlines and carriage returns (i.e., `\n`, `\r`) from the input, as these are the primary characters used for log forging. In this code, `projectId` is interpolated into a log message—in the `catch` block at line 77. We should sanitize `projectId` before including it in the log statement. The ideal solution is to create a local sanitized variable, where we remove newline and carriage return characters from `projectId`, and use that variable in the log statement.

As we must not change logging of `e` (the error), only the tainted entry should be sanitized. This change should go in `src/use-cases/projects/EditProject.ts`, inside the `catch` block of `execute`.

**Summary of changes:**
- Before the log statement in the `catch`, define `const safeProjectId = projectId.replace(/\r|\n/g, "")`.
- Use `safeProjectId` instead of `projectId` in the log statement.

No new dependencies or imports are required, as this uses standard JavaScript string replacement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
