### PR TITLE
Potential fix for code scanning alert no. 4: Log injection

### DIFF
--- a/src/use-cases/projects/UpdateProject.ts
+++ b/src/use-cases/projects/UpdateProject.ts
@@ -27,8 +27,10 @@ export class UpdateProject extends BaseMutationUseCase<UpdateProjectParams> {
       .insert({ project_id: projectId, update: sanitizedUpdate });
 
     if (error) {
+      // Remove newlines from projectId before logging to prevent log injection.
+      const safeProjectId = typeof projectId === 'string' ? projectId.replace(/[\n\r]/g, "") : "";
       console.error(
-        `Creating project update failed with: ${JSON.stringify(error, null, 2)} for project id: ${projectId}`
+        `Creating project update failed with: ${JSON.stringify(error, null, 2)} for project id: ${safeProjectId}`
       );
       return { success: false, message: 'Creating Update failed' };
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Christin-paige/BuiltInPublic/security/code-scanning/4](https://github.com/Christin-paige/BuiltInPublic/security/code-scanning/4)

The best fix is to sanitize `projectId` before logging it. Since the log file is presumably in plain text—as is common with `console.error`—the input should be stripped of characters that could introduce new lines (such as `\n` and `\r`), which would prevent log injection. 

This can be achieved by defining a local variable (e.g., `safeProjectId`) that replaces all newline and carriage return characters in `projectId` with an empty string, and using this sanitized version in the log entry. No additional dependencies are needed, as this can be handled with JavaScript's native `String.prototype.replace` and a regular expression. 

Only the log line(s) using `projectId` in `src/use-cases/projects/UpdateProject.ts` need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
